### PR TITLE
Periodic account activation

### DIFF
--- a/conf/bnetd.conf.in
+++ b/conf/bnetd.conf.in
@@ -405,6 +405,9 @@ passfail_bantime = 300
 # Max users limit in private channels (0 = unlimited)
 maxusers_per_channel = 0
 
+# Whether players need to periodically activate accounts on the web
+require_activation = false
+
 #                                                                            #
 ##############################################################################
 

--- a/src/bnetd/account_wrap.cpp
+++ b/src/bnetd/account_wrap.cpp
@@ -574,7 +574,16 @@ namespace pvpgn
 			return account_set_numattr(account, "BNET\\acct\\lastlogin_time", t);
 		}
 
+		/* Activation time */
+		extern unsigned int account_get_activation_time(t_account * account)
+		{
+			return account_get_numattr(account, "BNET\\acct\\activation_time");
+		}
 
+		extern unsigned int account_set_activation_time(t_account * account, unsigned int t)
+		{
+			return account_set_numattr(account, "BNET\\acct\\activation_time", t);
+		}
 
 		extern t_clienttag account_get_ll_clienttag(t_account * account)
 		{
@@ -1958,6 +1967,7 @@ namespace pvpgn
 
 			if ((flist = account_get_friends(account)) == NULL)
 				return -1;
+
 
 			if ((fr = friendlist_find_username(flist, frienduid)) == NULL) return -2;
 

--- a/src/bnetd/account_wrap.h
+++ b/src/bnetd/account_wrap.h
@@ -106,6 +106,8 @@ namespace pvpgn
 		extern unsigned int account_get_ll_ctime(t_account * account);
 		extern unsigned int account_get_ll_time(t_account * account);
 		extern int account_set_ll_time(t_account * account, unsigned int t);
+		extern unsigned int account_get_activation_time(t_account * account);
+		extern unsigned int account_set_activation_time(t_account * account, unsigned int t);
 		extern char const * account_get_ll_user(t_account * account);
 		extern int account_set_ll_user(t_account * account, char const * user);
 		extern t_clienttag account_get_ll_clienttag(t_account * account);

--- a/src/bnetd/handle_bnet.cpp
+++ b/src/bnetd/handle_bnet.cpp
@@ -1700,6 +1700,17 @@ namespace pvpgn
 						bn_int_set(&rpacket->u.server_loginreply1.message, SERVER_LOGINREPLY2_MESSAGE_BADPASS);
 					}
 				}
+				else if (account_get_activation_time(account) < (unsigned int)now && prefs_get_require_activation()) {
+					eventlog(eventlog_level_info, __FUNCTION__, "[%d] login for \"%s\" refused (this account needs to be activated)", conn_get_socket(c), username);
+					if (supports_locked_reply) {
+						bn_int_set(&rpacket->u.server_loginreply1.message, SERVER_LOGINREPLY2_MESSAGE_LOCKED);
+						std::string msgtemp = localize(c, "You must activate your account.");
+						packet_append_string(rpacket, msgtemp.c_str());
+					}
+					else {
+						bn_int_set(&rpacket->u.server_loginreply1.message, SERVER_LOGINREPLY2_MESSAGE_BADPASS);
+					}
+				}
 				else if (conn_get_sessionkey(c) != bn_int_get(packet->u.client_loginreq2.sessionkey)) {
 					eventlog(eventlog_level_error, __FUNCTION__, "[%d] login for \"%s\" refused (expected session key 0x%08x, got 0x%08x)", conn_get_socket(c), username, conn_get_sessionkey(c), bn_int_get(packet->u.client_loginreq2.sessionkey));
 					bn_int_set(&rpacket->u.server_loginreply2.message, SERVER_LOGINREPLY2_MESSAGE_BADPASS);
@@ -2118,6 +2129,12 @@ namespace pvpgn
 					bn_int_set(&rpacket->u.server_logonproofreply.response, SERVER_LOGONPROOFREPLY_RESPONSE_CUSTOM);
 					std::string msgtemp = localize(c, "This account has been locked");
 					msgtemp += account_get_locktext(account, true);
+					packet_append_string(rpacket, msgtemp.c_str());
+				}
+				else if (account_get_activation_time(account) < (unsigned int)now && prefs_get_require_activation()) {
+					eventlog(eventlog_level_info, __FUNCTION__, "[%d] login for \"%s\" refused (this account needs to be activated)", conn_get_socket(c), username);
+					bn_int_set(&rpacket->u.server_logonproofreply.response, SERVER_LOGONPROOFREPLY_RESPONSE_CUSTOM);
+					std::string msgtemp = localize(c, "You must activate your account.");
 					packet_append_string(rpacket, msgtemp.c_str());
 				}
 				else {

--- a/src/bnetd/prefs.cpp
+++ b/src/bnetd/prefs.cpp
@@ -156,6 +156,7 @@ namespace pvpgn
 			unsigned int passfail_count;
 			unsigned int passfail_bantime;
 			unsigned int maxusers_per_channel;
+			unsigned int require_activation;
 			char const * supportfile;
 			char const * allowed_clients;
 			char const * ladder_games;
@@ -641,6 +642,10 @@ namespace pvpgn
 		static const char *conf_get_maxusers_per_channel(void);
 		static int conf_setdef_maxusers_per_channel(void);
 
+		static int conf_set_require_activation(const char *valstr);
+		static const char *conf_get_require_activation(void);
+		static int conf_setdef_require_activation(void);
+
 		static int conf_set_allowed_clients(const char *valstr);
 		static const char *conf_get_allowed_clients(void);
 		static int conf_setdef_allowed_clients(void);
@@ -829,6 +834,7 @@ namespace pvpgn
 			{ "passfail_count", conf_set_passfail_count, conf_get_passfail_count, conf_setdef_passfail_count },
 			{ "passfail_bantime", conf_set_passfail_bantime, conf_get_passfail_bantime, conf_setdef_passfail_bantime },
 			{ "maxusers_per_channel", conf_set_maxusers_per_channel, conf_get_maxusers_per_channel, conf_setdef_maxusers_per_channel },
+			{ "require_activation", conf_set_require_activation, conf_get_require_activation, conf_setdef_require_activation },
 			{ "allowed_clients", conf_set_allowed_clients, conf_get_allowed_clients, conf_setdef_allowed_clients },
 			{ "ladder_games", conf_set_ladder_games, conf_get_ladder_games, conf_setdef_ladder_games },
 			{ "max_connections", conf_set_max_connections, conf_get_max_connections, conf_setdef_max_connections },
@@ -3337,6 +3343,27 @@ namespace pvpgn
 		static const char* conf_get_maxusers_per_channel(void)
 		{
 			return conf_get_int(prefs_runtime_config.maxusers_per_channel);
+		}
+
+
+		extern unsigned int prefs_get_require_activation(void)
+		{
+			return prefs_runtime_config.require_activation;
+		}
+
+		static int conf_set_require_activation(const char *valstr)
+		{
+			return conf_set_bool(&prefs_runtime_config.require_activation, valstr, 0);
+		}
+
+		static int conf_setdef_require_activation(void)
+		{
+			return conf_set_bool(&prefs_runtime_config.require_activation, NULL, 0);
+		}
+
+		static const char* conf_get_require_activation(void)
+		{
+			return conf_get_bool(prefs_runtime_config.require_activation);
 		}
 
 

--- a/src/bnetd/prefs.h
+++ b/src/bnetd/prefs.h
@@ -172,6 +172,7 @@ namespace pvpgn
 		extern unsigned int prefs_get_passfail_count(void);
 		extern unsigned int prefs_get_passfail_bantime(void);
 		extern unsigned int prefs_get_maxusers_per_channel(void);
+		extern unsigned int prefs_get_require_activation(void);
 		extern char const * prefs_get_supportfile(void);
 		extern char const * prefs_get_allowed_clients(void);
 		extern char const * prefs_get_ladder_games(void);


### PR DESCRIPTION
New config option `require_activation = bool`. This turns on/off the account activation system. If turned on, players must periodically activate their accounts on the web. The web form updates `BNET\acct\activation_time` to unix timestamp in the future. Account is then activated up to that time. The primary use of this is to drive additional ad revenue on your website.
