### PR TITLE
i18n.cpp encoding changed to UTF8 without BOM because it breaks compilat...

### DIFF
--- a/src/bnetd/i18n.cpp
+++ b/src/bnetd/i18n.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 * Copyright (C) 2014  HarpyWar (harpywar@gmail.com)
 *
 * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
...ion with `error: stray XXX in program`. Do not use BOM, ever.

Breakage noticed on OpenBSD 5.5
