### PR TITLE
Update Travis CI to use Trusty (Ubuntu 14.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - sourceline: 'george-edison55/cmake-3.x'
+      - sourceline: 'ppa:george-edison55/cmake-3.x'
     packages:
       - gcc-5
       - g++-5

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ branches:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r/test
-      - george-edison55/cmake-3.x
+      - ubuntu-toolchain-r-test
+      - sourceline: 'george-edison55/cmake-3.x'
     packages:
       - gcc-5
       - g++-5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,32 @@
 sudo: required
-
-branches:
-  only:
-    - master
+dist: trusty
 
 language: cpp
 os: linux
 compiler: gcc
+  
+branches:
+  only:
+    - master
 
-before_install:
-  - sudo apt-get update --fix-missing
-  - sudo apt-get install build-essential zlib1g-dev libmysqlclient-dev liblua5.1-0-dev
-  - (cd /tmp && wget --no-check-certificate https://cmake.org/files/v3.4/cmake-3.4.0.tar.gz && tar zxf cmake-3.4.0.tar.gz)
-  - (cd /tmp/cmake-3.4.0 && cmake . && make && sudo make install) > /dev/null 2>&1
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get -qq update
-  - sudo apt-get -qq install g++-5
-  - export CXX="g++-5" CC="gcc-5"
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+	  - george-edison55/cmake-3.x
+    packages:
+      - gcc-5
+      - g++-5
+      - zlib1g-dev
+	  - build-essential
+	  - libmysqlclient-dev
+	  - liblua5.1-0-dev
+	  - cmake
+  
+before_script:
   - mkdir build
   - cd build
-  
+
 script:
   - cmake -D WITH_MYSQL=true -D WITH_LUA=true ../
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ addons:
       - libmysqlclient-dev
       - liblua5.1-0-dev
       - cmake
+
+before_install:
+  - export CXX="g++-5" CC="gcc-5"
   
 before_script:
   - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,16 @@ branches:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
-	  - george-edison55/cmake-3.x
+      - ubuntu-toolchain-r/test
+      - george-edison55/cmake-3.x
     packages:
       - gcc-5
       - g++-5
       - zlib1g-dev
-	  - build-essential
-	  - libmysqlclient-dev
-	  - liblua5.1-0-dev
-	  - cmake
+      - build-essential
+      - libmysqlclient-dev
+      - liblua5.1-0-dev
+      - cmake
   
 before_script:
   - mkdir build


### PR DESCRIPTION
Builds now only take 2 minutes whereas before, builds took around 6 minutes.