### PR TITLE
- move packet limit option to config

### DIFF
--- a/conf/bnetd.conf.in
+++ b/conf/bnetd.conf.in
@@ -477,6 +477,11 @@ contact_email = "unknown"
 # limit, NOT the concurrent user limit (for that see next option)
 max_connections = 1000
 
+# Set maximum amount of packets in client packet queue
+# If limit is reached, client connection will be dropped
+# Set to 0 to disable
+packet_limit = 1000
+
 # Maximum number of concurrent users (0 means unlimited).
 max_concurrent_logins = 0
 

--- a/conf/bnetd.conf.win32
+++ b/conf/bnetd.conf.win32
@@ -457,6 +457,11 @@ contact_email = "unknown"
 # limit, NOT the concurrent user limit (for that see next option)
 max_connections = 1000
 
+# Set maximum amount of packets in client packet queue
+# If limit is reached, client connection will be dropped
+# Set to 0 to disable
+packet_limit = 1000
+
 # Maximum number of concurrent users (0 means unlimited).
 max_concurrent_logins = 0
 

--- a/src/bnetd/connection.cpp
+++ b/src/bnetd/connection.cpp
@@ -75,6 +75,7 @@
 #include "icons.h"
 #include "i18n.h"
 #include "common/setup_after.h"
+#include "prefs.h"
 
 #ifdef WITH_LUA
 #include "luainterface.h"
@@ -2272,11 +2273,11 @@ namespace pvpgn
 			// Protection from hack attempt
 			// Limit out queue packets due to it may cause memory leak with not enough memory program crash on a server machine
 			t_queue ** q = &c->protocol.queues.outqueue;
-			if (queue_get_length((t_queue const * const *)q) > 1000)
+			if (prefs_get_packet_limit() && queue_get_length((t_queue const * const *)q) > prefs_get_packet_limit())
 			{
 				queue_clear(q);
 				conn_set_state(c, conn_state_destroy);
-				eventlog(eventlog_level_error, __FUNCTION__, "outqueue reached limit of 1000 packets (hack attempt?)");
+				eventlog(eventlog_level_error, __FUNCTION__, "outqueue reached limit of {} packets (hack attempt?)", prefs_get_packet_limit());
 				return 0;
 			}
 

--- a/src/bnetd/luainterface.cpp
+++ b/src/bnetd/luainterface.cpp
@@ -268,6 +268,7 @@ namespace pvpgn
 				config.update("contact_email", prefs_get_contact_email());
 				config.update("servername", prefs_get_servername());
 				config.update("max_connections", prefs_get_max_connections());
+				config.update("packet_limit", prefs_get_packet_limit());
 				config.update("max_concurrent_logins", prefs_get_max_concurrent_logins());
 				config.update("use_keepalive", prefs_get_use_keepalive());
 				config.update("max_conns_per_IP", prefs_get_max_conns_per_IP());

--- a/src/bnetd/prefs.cpp
+++ b/src/bnetd/prefs.cpp
@@ -161,6 +161,7 @@ namespace pvpgn
 			char const * ladder_games;
 			char const * ladder_prefix;
 			unsigned int max_connections;
+			unsigned int packet_limit;
 			unsigned int sync_on_logoff;
 			char const * irc_network_name;
 			unsigned int localize_by_country;
@@ -656,6 +657,10 @@ namespace pvpgn
 		static const char *conf_get_max_connections(void);
 		static int conf_setdef_max_connections(void);
 
+		static int conf_set_packet_limit(const char *valstr);
+		static const char *conf_get_packet_limit(void);
+		static int conf_setdef_packet_limit(void);
+
 		static int conf_set_sync_on_logoff(const char *valstr);
 		static const char *conf_get_sync_on_logoff(void);
 		static int conf_setdef_sync_on_logoff(void);
@@ -847,6 +852,7 @@ namespace pvpgn
 			{ "allowed_clients", conf_set_allowed_clients, conf_get_allowed_clients, conf_setdef_allowed_clients },
 			{ "ladder_games", conf_set_ladder_games, conf_get_ladder_games, conf_setdef_ladder_games },
 			{ "max_connections", conf_set_max_connections, conf_get_max_connections, conf_setdef_max_connections },
+			{ "packet_limit", conf_set_packet_limit, conf_get_packet_limit, conf_setdef_packet_limit },
 			{ "sync_on_logoff", conf_set_sync_on_logoff, conf_get_sync_on_logoff, conf_setdef_sync_on_logoff },
 			{ "ladder_prefix", conf_set_ladder_prefix, conf_get_ladder_prefix, conf_setdef_ladder_prefix },
 			{ "irc_network_name", conf_set_irc_network_name, conf_get_irc_network_name, conf_setdef_irc_network_name },
@@ -3460,6 +3466,27 @@ namespace pvpgn
 		static const char* conf_get_max_connections(void)
 		{
 			return conf_get_int(prefs_runtime_config.max_connections);
+		}
+
+
+		extern unsigned int prefs_get_packet_limit(void)
+		{
+			return prefs_runtime_config.packet_limit;
+		}
+
+		static int conf_set_packet_limit(const char *valstr)
+		{
+			return conf_set_int(&prefs_runtime_config.packet_limit, valstr, 0);
+		}
+
+		static int conf_setdef_packet_limit(void)
+		{
+			return conf_set_int(&prefs_runtime_config.packet_limit, NULL, BNETD_PACKET_LIMIT);
+		}
+
+		static const char* conf_get_packet_limit(void)
+		{
+			return conf_get_int(prefs_runtime_config.packet_limit);
 		}
 
 

--- a/src/bnetd/prefs.h
+++ b/src/bnetd/prefs.h
@@ -177,6 +177,7 @@ namespace pvpgn
 		extern char const * prefs_get_ladder_games(void);
 		extern char const * prefs_get_ladder_prefix(void);
 		extern unsigned int prefs_get_max_connections(void);
+		extern unsigned int prefs_get_packet_limit(void);
 		extern unsigned int prefs_get_sync_on_logoff(void);
 		extern char const * prefs_get_irc_network_name(void);
 		extern unsigned int prefs_get_localize_by_country(void);

--- a/src/common/setup_before.h
+++ b/src/common/setup_before.h
@@ -215,6 +215,7 @@ const int BNETD_MAX_TEST_PORT = 6500;
 const unsigned BNETD_USERSYNC = 300; /* s */
 const unsigned BNETD_USERFLUSH = 1000;
 const unsigned BNETD_USERSTEP = 100; /* check 100 users per call in accountlist_save() */
+const unsigned BNETD_PACKET_LIMIT = 1000; /* maximum of 1000 packets in packet queue until connections is dropped */
 const unsigned BNETD_LATENCY = 600; /* s */
 const unsigned BNETD_IRC_LATENCY = 180; /* s */ /* Ping timeout for IRC connections */
 const unsigned BNETD_DEF_NULLMSG = 120; /* s */


### PR DESCRIPTION
Can't update client from 1.07 to 1.13c without increasing this value. 1000 is too low. Values >= 2k seem to be ok