### PR TITLE
use libc++ with clang by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if (MSVC)
 endif ()
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pedantic")
+       set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pedantic -stdlib=libc++")
   
        # Pass CXX flags to flags.
        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DSEQAN_CXX_FLAGS_=\"${CMAKE_CXX_FLAGS}\"")


### PR DESCRIPTION
Basically, on Debian it is hard to get gcc5 so the simplest solution is to use clang 3.5 which supports c++11. But without explicitly requesting libc++ to be used, it would still use system glibc, resulting in failed compile.