### PR TITLE
fixes issue 314

### DIFF
--- a/src/bnetd/anongame.cpp
+++ b/src/bnetd/anongame.cpp
@@ -1015,7 +1015,6 @@ namespace pvpgn
 			/* clear queue */
 			players[queue] = 0;
 			xfree(pt2);
-			anongameinfo_destroy(info);
 
 			return 0;
 		}


### PR DESCRIPTION
This is a fast fix for PG search crash. Commit 5a9ce9cce4cec7765fb7fd49cf703d3cad136630 is at fault and it should be reviewed further because it contains 2 more added `anongameinfo_destroy(info);` which apparently free pointers/connection which it shouldn't. Personaly didn't have time to research too deep into it.