### PR TITLE
Fix server listing for Renegade

### DIFF
--- a/src/bnetd/handle_wol.cpp
+++ b/src/bnetd/handle_wol.cpp
@@ -1319,8 +1319,6 @@ namespace pvpgn
 					std::strcat(temp, ":");
 				}
 
-				game_set_status(game, game_status_started);
-
 				if (conn_get_clienttag(conn) == CLIENTTAG_RENEGADE_UINT || conn_get_clienttag(conn) == CLIENTTAG_RENGDFDS_UINT)
 				{
 					game_set_status(game, game_status_open);


### PR DESCRIPTION
This removes a line leftover from a patch, that prevents C&C Renegade from listing properly.